### PR TITLE
Changes to pt_poll_week1

### DIFF
--- a/poll_everywhere/pt_poll_week1.tex
+++ b/poll_everywhere/pt_poll_week1.tex
@@ -1,0 +1,147 @@
+\documentclass[poll_tutorial_format]{subfiles}
+\begin{document}
+	\maketitle
+		\setcounter{section}{0}
+	\section{PT Week 1 (counting and naive probability)}
+	
+	\subsection{Set things up}
+	\label{sec:set-things-up}
+	
+	
+	
+	\setcounter{theorem}{-1}
+	\begin{exercise}
+		Have you helped your neighbors to set up their polleverywhere app?
+		\begin{enumerate}
+			\item Yes
+			\item No
+		\end{enumerate}
+	\end{exercise}
+	
+	\subsection{Real questions}
+	\label{sec:start-real-questions pt week1}
+	\begin{exercise}
+		A fair coin is flipped ten times, how many possible outcomes in total, e.g., two heads is one outcome?		
+		Choose one of these answers: 
+		\begin{enumerate}
+			\item $10^2$
+			\item $2^{10}$
+			\item ${10\choose 2}$
+			\item $2! * 10$
+			\item $10!/(10-2)!$
+		\end{enumerate}
+	\end{exercise}
+	
+	
+	\begin{exercise}
+		A fair coin is flipped ten times, how many possible outcomes are there such that five out of the ten tosses are heads?				
+		Choose one of these answers:
+		\begin{enumerate}
+			\item $10!/5!$
+			\item $10!/(5!)^2$
+			\item $2^{10}/2^{5}$
+			\item ${10 \choose 5}$
+			\item ${10 \choose 5}^2$
+		\end{enumerate}
+	\end{exercise}
+
+	\begin{exercise}
+	Which one of these answers is \textbf{not} correct: 
+	\begin{enumerate}
+		\item An event is a set of some outcomes of which a probability value can be defined.
+		\item The sample space is not an event.
+		\item An event is a subset of the sample space.
+		\item Sample space contains all possible outcomes for a given experiment.
+		\item If an event always occurrs, then the event must be the sample space.
+		\item Sample space is not unique.
+	\end{enumerate}
+\end{exercise}
+
+	
+	\begin{exercise}
+		A fair coin is flipped ten times, and  consider to construct a sample space based on this probability game though we may not be interested in the full game, denote $H_i$ the $i$th toss lands head and $T_i$ tail. 
+		Which one of these answers are not a proper sample space:
+		\begin{enumerate}
+			\item $\{H_1, T_1\}$
+			\item $\{H_1H_2, T_1T_2, H_1T_2, T_1H_2\}$
+			\item $\{X_1X_2\cdots X_{10}: X_i \in \{H_i,T_i\}\}$
+			\item $\{H_1, T_1\}\times\{H_2, T_2\}\times  \cdots \times \{H_{10}, T_{10}\}$
+			\item $\{H_1, H_2\}$
+		\end{enumerate}
+	\end{exercise}
+	
+	\begin{exercise}
+		A fair coin is flipped ten times, and one considers to construct a sample space based on this game: denote $H_i$, the $i$th toss being heads, and $T_i$, the $i$th toss being tails. What is the probability $P( \{H_1T_2\} \cap \{T_2\} )$?
+		Choose one of these answers:
+		\begin{enumerate}
+			\item 1/2
+			\item 1/3
+			\item 1/4
+			\item 1/8
+		\end{enumerate}
+	\end{exercise}
+
+	\begin{exercise}
+		A fair coin is flipped ten times, and one considers to construct a sample space based on this game: denote $H_i$, the $i$th toss being heads, and $T_i$, the $i$th toss being tails. What is the probability $P( \{H_1T_2\} \cup \{T_2\} )$?
+	Choose one of these answers:
+	\begin{enumerate}
+		\item 1/2
+		\item 1/3
+		\item 1/4
+		\item 1/8
+	\end{enumerate}
+\end{exercise}
+
+	\begin{exercise}
+		A fair coin is flipped ten times, and one considers to construct a sample space based on this game: denote $H_i$, the $i$th toss being heads, and $T_i$, the $i$th toss being tails. 
+	Which one of these answers is incorrect:
+	\begin{enumerate}
+		\item $P( \{H_1\} \cap \{T_2\} )=P( \{H_1\})P( \{T_2\} )$
+		\item $P( \{H_1 \} \cap \{T_1\} )\neq  P( \{H_1\})P( \{T_1\} )$
+		\item $P( \{H_1T_2\} \cup \{T_2\} )=P( \{H_1T_2\} )+P( \{T_2\} )$
+		\item $P( \{H_1T_2\} \cup \{T_2\} )=P( \{H_1T_2\} )+P( \{T_2\} )-P( \{H_1T_2\} )$
+	\end{enumerate}
+\end{exercise}
+
+
+	\begin{exercise}
+	A fair coin is flipped ten times, and one is consider to construct a sample space based on this game, denote $H_i$ the $i$th toss lands head and $T_i$ tail. 
+	Which one of these answers is incorrect:
+	\begin{enumerate}
+		\item $P( \{H_1\})=P( \{H_1\}^c)$
+		\item $P( \{H_1 \} )=P( \{T_1\} )$
+		\item $P( \{H_1\} \cup \{T_1\} )=0$
+		\item $P( \{H_1T_2\} \cup \{T_2\} )=P( \{H_1T_2\} ) $
+	\end{enumerate}
+\end{exercise}
+
+
+	
+	\begin{exercise}
+		${n\choose k}$ equals?
+		Choose one of these answers:
+		\begin{enumerate}
+			\item $\frac{n!}{(n-k)!}$
+			\item $\frac{n!}{k!}$
+			\item ${n-1\choose k-1} +{n-1\choose k}$
+			\item $\frac{n!}{(n-k)^k}$
+			\item $\frac{n!}{k^{n-k}}$
+		\end{enumerate}
+	\end{exercise}
+	
+	\begin{exercise}
+		Suppose we have a sample space $S$ with subsets/events $A$ and $B$.
+			Which one of these answers is always incorrect:
+		\begin{enumerate}
+			\item $P(A)=0$
+			\item $P(A)=1$
+			\item $P(A)=-0.1$
+			\item $P(A)-P(B)=-0.1$
+			\item $P(A)+P(B)=5/4$
+		\end{enumerate}
+	\end{exercise}
+	 
+  
+ 
+ 
+\end{document}

--- a/poll_everywhere/pt_poll_week2.tex
+++ b/poll_everywhere/pt_poll_week2.tex
@@ -1,0 +1,148 @@
+\documentclass[poll_tutorial_format]{subfiles}
+\begin{document}
+	\maketitle
+		\setcounter{section}{1}
+	\section{PT Week 2 ((Non-naive) probability and conditional probability)}
+	
+	\subsection{Set things up}
+	\label{sec:set-things-up}
+	
+	
+	
+	\setcounter{theorem}{-1}
+
+	\begin{exercise}
+		Have you helped your neighbors to set up their polleverywhere app? 
+		\begin{enumerate}
+			\item Yes
+			\item No
+		\end{enumerate}
+	\end{exercise}
+	
+	\subsection{Real questions}
+	\label{sec:start-real-questions pt week 2}
+			\begin{exercise}
+		Suppose we have a sample space $S$ with subsets/events $A$ and $B$ such that $P(A)\neq 0$.
+		Which one of these answers could be incorrect:
+		\begin{enumerate}
+			\item $P(B|A)=\frac{P(A\cap B)}{P(A)}$
+			\item $P(A)=P(B|A)P(A)$
+			\item $P(\emptyset)=0$
+			\item $P(B|A)+P(B|A^c)=1$
+			\item $P(B|A)+P(B^c|A)=1$
+			\item $P(A|S)=P(A)$
+			\item $P(B)=P(B|S)$
+		\end{enumerate}
+	\end{exercise}
+
+	
+
+
+\begin{exercise}
+	Which one of these answers is not part of (or implied by) the definition of the non-naive probability?
+	Choose one of these answers: 
+	\begin{enumerate}
+		\item $P(S)=1$
+		\item $P(\cup_i A_i) = \sum_i P(A_i)$ for arbitrary events $A_i$'s
+		\item $P(A\cup B)=P(A)+P(B)-P(A\cap B)$
+		\item $P(\emptyset)=1-P(S)$
+	\end{enumerate}
+\end{exercise}
+
+
+
+\begin{exercise}
+	(Coin tossing problem) A fair coin is flipped two times, event A represents both tosses landing heads and B represents the event that the first toss landed tails. 
+	Which of these answers is incorrect: 
+	\begin{enumerate}
+		\item $P(B\cup B^c )=P(B)+P(B^c)$
+		\item $P(B\cup B^c |A)=P(B|A)+P(B^c|A)$
+		\item $P(A|B^c)=P(B^c|A)$
+		\item $P(A|B)=0$
+		\item $P(A|B^c)=P(B)$
+	\end{enumerate}
+\end{exercise}
+
+
+\begin{exercise}
+	Here are some statements regarding the conditional probability (where $P(A)\neq 0$, and $S$ is the sample space).
+	Which of these answers may be incorrect: 
+	\begin{enumerate}
+		\item $P(S|A)=1$
+		\item $P(\cup_{i=1}^\infty B_i|A) = \sum_{i=1}^\infty P(B_i|A)$ for disjoint events $B_i$'s
+		\item $P(B|A)+P(B^c|A)=1$
+		\item $P(B|A)+P(B|A^c)=1$ 
+		\item Suppose that $A$ and $B$ are independent then $P(B|A)=P(B)$ and $P(B|A)P(A)=P(B)P(A)$ 
+	\end{enumerate}
+\end{exercise}
+
+
+\begin{exercise}
+	Which of these answers may be incorrect: 
+	\begin{enumerate}
+		\item If $P(A|B)=P(A)$, then Event A is independent from Event B.
+		\item If Event A is independent from Event B, then $P(A|B)=P(A)$ and $P(B|A)=P(B)$.
+		\item If Event A is independent from Event B, then $P(A\cap B)=P(A)P(B)$.
+	\end{enumerate}
+\end{exercise}
+
+
+\begin{exercise}
+	(Coin tossing problem) A fair coin is flipped two times, event A represents both tosses landing heads, B represents the event that the first toss landed tails and C represents the event that the second toss landed tails. 
+Which of these answers is incorrect: 
+\begin{enumerate}
+		\item $P(A)=P(A|B)P(B)+P(A|B^c)P(B^c)$ 
+		\item $P(A|B^c)=1/2$
+		\item $P(B^c\cap C^c)=P(B^c)P(C^c)$ 
+		\item $P(B^c\cap C^c|A)=P(B^c|A)P(C^c|A) $  
+	\end{enumerate}
+\end{exercise}
+
+\begin{exercise}
+	(Coin tossing problem) A fair coin is flipped two times, event A represents both tosses landing heads, B represents the event that the first toss landed tails and C represents the event that the second toss landed tails. 
+	Which of these answers is correct: 
+	\begin{enumerate}
+		\item $P(A|B)=P(A)$  
+		\item $P(B|B^c)=1$
+		\item $P(B| C)=P(B)P(C)$  
+		\item $P(B\cap C|A)=P(B|A)P(C|A)$ and hence $B$ and $C$ are conditionally independent given event $A$.  
+	\end{enumerate}
+\end{exercise}
+
+
+\begin{exercise} 
+Is the following statement right or wrong?\\~\\ Event A is independent from Event B if and only if $$P(A\cap B)=P(A)P(B),$$ and it is possible that $P(A|B)$ (or $P(B|A)$ or both) is not defined. 
+	\begin{enumerate}
+		\item Right.
+		\item  Wrong.
+		\item Neither of above.
+	\end{enumerate}
+\end{exercise}
+
+
+\begin{exercise} 
+	Which of these statements is correct: 
+	\begin{enumerate}
+		\item Independence of events $A$ and $B$ implies that $A$ and $B$ are conditional independent as well.
+		\item If $A$ and $B$ are conditional independent given event implies that $A$ and $B$ are independent. 
+		\item If $A$ and $B$ are independent, we always have $P(A|B)=P(A)$. 
+		\item  $\emptyset$ is independent from any events $A$, though $P(A|\emptyset)$ is not defined.
+	\end{enumerate}
+\end{exercise}
+
+
+\begin{exercise}
+	Which of these statements is incorrect: 
+	\begin{enumerate}
+		\item If events A, B and C are independent, then we must have $P(A\cap B\cap C)=P(A)P(B)P(C)$.
+		\item In practice, we use $P(A|B,C)$ to denote $P(A|B\cup C)$. 
+		\item $P(T_3|T_1,T_2)=\frac{P(T_3\cap T_2|T_1)}{P(T_2|T_1)}$ where we assume $P(T_1\cap T_2)>0$. 
+		\item $P(T_3|T_1,T_2)=\frac{P(T_3\cap T_1|T_2)}{P(T_1|T_2)}$ where we assume $P(T_1\cap T_2)>0$. 
+	\end{enumerate}
+\end{exercise}
+
+	
+ 	
+	
+	
+\end{document}

--- a/poll_everywhere/pt_poll_week2.tex
+++ b/poll_everywhere/pt_poll_week2.tex
@@ -52,7 +52,7 @@
 
 
 \begin{exercise}
-	(Coin tossing problem) A fair coin is flipped two times, event A represents both tosses landing heads and B represents the event that the first toss landed tails. 
+	(Coin tossing problem) A fair coin is flipped two times, event $A$ represents both tosses landing heads and $B$ represents the event that the first toss landed tails. 
 	Which of these answers is incorrect: 
 	\begin{enumerate}
 		\item $P(B\cup B^c )=P(B)+P(B^c)$
@@ -80,15 +80,15 @@
 \begin{exercise}
 	Which of these answers may be incorrect: 
 	\begin{enumerate}
-		\item If $P(A|B)=P(A)$, then Event A is independent from Event B.
-		\item If Event A is independent from Event B, then $P(A|B)=P(A)$ and $P(B|A)=P(B)$.
-		\item If Event A is independent from Event B, then $P(A\cap B)=P(A)P(B)$.
+		\item If $P(A|B)=P(A)$, then Event $A$ is independent from Event $B$.
+		\item If Event $A$ is independent from Event $B$, then $P(A|B)=P(A)$ and $P(B|A)=P(B)$.
+		\item If Event $A$ is independent from Event $B$, then $P(A\cap B)=P(A)P(B)$.
 	\end{enumerate}
 \end{exercise}
 
 
 \begin{exercise}
-	(Coin tossing problem) A fair coin is flipped two times, event A represents both tosses landing heads, B represents the event that the first toss landed tails and C represents the event that the second toss landed tails. 
+	(Coin tossing problem) A fair coin is flipped two times, event $A$ represents both tosses landing heads, $B$ represents the event that the first toss landed tails and $C$ represents the event that the second toss landed tails. 
 Which of these answers is incorrect: 
 \begin{enumerate}
 		\item $P(A)=P(A|B)P(B)+P(A|B^c)P(B^c)$ 
@@ -99,7 +99,7 @@ Which of these answers is incorrect:
 \end{exercise}
 
 \begin{exercise}
-	(Coin tossing problem) A fair coin is flipped two times, event A represents both tosses landing heads, B represents the event that the first toss landed tails and C represents the event that the second toss landed tails. 
+	(Coin tossing problem) A fair coin is flipped two times, event $A$ represents both tosses landing heads, $B$ represents the event that the first toss landed tails and $C$ represents the event that the second toss landed tails. 
 	Which of these answers is correct: 
 	\begin{enumerate}
 		\item $P(A|B)=P(A)$  
@@ -111,7 +111,7 @@ Which of these answers is incorrect:
 
 
 \begin{exercise} 
-Is the following statement right or wrong?\\~\\ Event A is independent from Event B if and only if $$P(A\cap B)=P(A)P(B),$$ and it is possible that $P(A|B)$ (or $P(B|A)$ or both) is not defined. 
+Is the following statement right or wrong?\\~\\ Event $A$ is independent from Event $B$ if and only if $$P(A\cap B)=P(A)P(B),$$ and it is possible that $P(A|B)$ (or $P(B|A)$ or both) is not defined. 
 	\begin{enumerate}
 		\item Right.
 		\item  Wrong.
@@ -134,7 +134,7 @@ Is the following statement right or wrong?\\~\\ Event A is independent from Even
 \begin{exercise}
 	Which of these statements is incorrect: 
 	\begin{enumerate}
-		\item If events A, B and C are independent, then we must have $P(A\cap B\cap C)=P(A)P(B)P(C)$.
+		\item If events $A$, $B$ and $C$ are independent, then we must have $P(A\cap B\cap C)=P(A)P(B)P(C)$.
 		\item In practice, we use $P(A|B,C)$ to denote $P(A|B\cup C)$. 
 		\item $P(T_3|T_1,T_2)=\frac{P(T_3\cap T_2|T_1)}{P(T_2|T_1)}$ where we assume $P(T_1\cap T_2)>0$. 
 		\item $P(T_3|T_1,T_2)=\frac{P(T_3\cap T_1|T_2)}{P(T_1|T_2)}$ where we assume $P(T_1\cap T_2)>0$. 


### PR DESCRIPTION
Removed all answers.
Changed the formulation of Ex 1.2.
Changed the formulation of sample space construction in Ex 1.5-1.8. Deleted "What is the probability $P( \{H_1T_2\} \cup \{T_2\} )$?" from Ex 1.7 and Ex 1.8.

Changed the formulation of Ex 1.10 (is incorrect -> is always incorrect).

Note: 
- Ex 1.2 answers 2 and 4 are equal, but only answer 2 is noted as correct.
- Ex 1.9 states "ans: $10!/(5!)^2$", this is the stated answer to Ex 1.2 (The correct answer is ${n-1\choose k-1} +{n-1\choose k}$).
- Ex 1.10 states "ans: $P( \{H_1T_2\} \cup \{T_2\} )=P( \{H_1T_2\} )$", this is the answer to Ex 1.8 (The correct answer is $P(A)=-0.1$).